### PR TITLE
Fix: Update Geodesic Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudposse/geodesic:0.147.11-alpine
+FROM cloudposse/geodesic:1.3.0-alpine
 
 
 ENV ASSUME_ROLE_INTERACTIVE=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM cloudposse/geodesic:1.3.0-alpine
 
-
 ENV ASSUME_ROLE_INTERACTIVE=false
 ENV AWS_SAML2AWS_ENABLED=false
 ENV AWS_VAULT_ENABLED=false


### PR DESCRIPTION
## what
- Updated the Geodesic image version

## why
- Attempting to resolve a downstream bug with the action:
```
usage: 
Note: AWS CLI version 2, the latest major version of the AWS CLI, is now stable and recommended for general use. For more information, see the AWS CLI version 2 installation instructions at: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument --name: expected one argument
```
