### PR TITLE
Add `qa` Environment

### DIFF
--- a/root/deploy/helmfile.yaml
+++ b/root/deploy/helmfile.yaml
@@ -3,6 +3,7 @@ environments:
   staging:
   production:
   dev:
+  qa:
   qa1:
   qa2:
   qa3:


### PR DESCRIPTION
## what
- Added qa as environment option

## why
- We only support qa1, qa2, etc as options. We should also support "qa" as an option as well

## references
- N/A
