### PR TITLE
Debug `webapp-url` Output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: Debug mode
     default: 'false'
     required: false
+  release_label_name:
+    description: The name of the label used to describe the helm release
+    default: "release"
+    required: false
 outputs:
   webapp-url:
     description: "Web Application url"
@@ -63,3 +67,4 @@ runs:
     GITREF_SHA: ${{ inputs.gitref-sha }}
     CLUSTER_NAME: ${{ inputs.cluster }}
     HELM_DEBUG: ${{ inputs.debug }}
+    RELEASE_LABEL_NAME: ${{ inputs.release_label_name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,14 +28,10 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 
-	RELEASES=$(helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
-	for RELEASE in ${RELEASES}
-  do
-  	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l release=${RELEASE} ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
-  	if [[ "${ENTRYPOINT}" != "" ]]; then
-  		echo "::set-output name=webapp-url::${ENTRYPOINT}"
-  	fi
-  done
+  ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
+  if [[ "${ENTRYPOINT}" != "" ]]; then
+  	echo "::set-output name=webapp-url::${ENTRYPOINT}"
+  fi
 
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,9 +31,9 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	RELEASES=$(helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
 	for RELEASE in ${RELEASES}
   do
-		ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
-  	if [[ "${ENTRYPOINT}" != "" ]]; then
-  		echo "::set-output name=webapp-url::${ENTRYPOINT}"
+	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
+		if [[ "${ENTRYPOINT}" != "" ]]; then
+			echo "::set-output name=webapp-url::${ENTRYPOINT}"
   	fi
   done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,11 +28,14 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 
-  ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
-  if [[ "${ENTRYPOINT}" != "" ]]; then
-  	echo "::set-output name=webapp-url::${ENTRYPOINT}"
-  fi
-
+	RELEASES=$(helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
+	for RELEASE in ${RELEASES}
+  do
+		ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
+  	if [[ "${ENTRYPOINT}" != "" ]]; then
+  		echo "::set-output name=webapp-url::${ENTRYPOINT}"
+  	fi
+  done
 
 
 elif [[ "${OPERATION}" == "destroy" ]]; then


### PR DESCRIPTION
## what
- Added RELEASE_LABEL_NAME input option

## why
- The `-l release=${RELEASE}` arg in [this line](https://github.com/cloudposse/github-action-deploy-helmfile/blob/main/entrypoint.sh#L34) does not work if the app uses a different label
- Parameterize that option

## references
```
⨠ kubectl --namespace foobar get -l release=app ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}'
 
⨠ kubectl --namespace foobar get ingress  --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}'
https://ops-qa-foobar.example-dev.com 

 ```
