### PR TITLE
Ahs extra values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: "Deploy HelmFile"
-description: "Deploy on Kubernetes with HelmFile"
+name: 'Deploy HelmFile'
+description: 'Deploy on Kubernetes with HelmFile'
 author: hello@cloudposse.com
 branding:
-  icon: "file-text"
-  color: "white"
+  icon: 'file-text'
+  color: 'white'
 inputs:
   cluster:
     description: Cluster name
@@ -31,7 +31,7 @@ inputs:
   gitref-sha:
     description: Git SHA
     required: false
-    default: ""
+    default: ''
   namespace:
     description: Kubernetes namespace
     required: true
@@ -43,11 +43,11 @@ inputs:
     required: true
   debug:
     description: Debug mode
-    default: "false"
+    default: 'false'
     required: false
   release_label_name:
     description: The name of the label used to describe the helm release
-    default: "release"
+    default: 'release'
     required: false
   values:
     description: Extra values to pass to the helm action (comma-separated NAME=VAL pairs)
@@ -57,10 +57,10 @@ inputs:
     required: false
 outputs:
   webapp-url:
-    description: "Web Application url"
+    description: 'Web Application url'
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: 'docker'
+  image: 'Dockerfile'
   env:
     AWS_REGION: ${{ inputs.aws-region }}
     ENVIRONMENT: ${{ inputs.environment }}

--- a/action.yml
+++ b/action.yml
@@ -49,9 +49,6 @@ inputs:
     description: The name of the label used to describe the helm release
     default: "release"
     required: false
-  values:
-    description: Extra values to pass to the helm action (comma-separated NAME=VAL pairs)
-    required: false
   values_yaml:
     description: YAML string with extra values to use in a helmfile deploy
     required: false
@@ -64,7 +61,6 @@ runs:
   env:
     AWS_REGION: ${{ inputs.aws-region }}
     ENVIRONMENT: ${{ inputs.environment }}
-    HELM_VALUES: ${{ inputs.values }}
     HELM_VALUES_YAML: ${{ inputs.values_yaml }}
     HELMFILE: ${{ inputs.helmfile }}
     HELMFILE_PATH: ${{ inputs.helmfile-path }}

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
   release_label_name:
     description: The name of the label used to describe the helm release
-    default: 'release'
+    default: "release"
     required: false
   values:
     description: Extra values to pass to the helm action (comma-separated NAME=VAL pairs)
@@ -57,7 +57,7 @@ inputs:
     required: false
 outputs:
   webapp-url:
-    description: 'Web Application url'
+    description: "Web Application url"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ inputs:
   values:
     description: Extra values to pass to the helm action (comma-separated NAME=VAL pairs)
     required: false
+  values_file:
+    description: Contents of a values file to use in the deployment
+    required: false
 outputs:
   webapp-url:
     description: "Web Application url"
@@ -62,6 +65,7 @@ runs:
     AWS_REGION: ${{ inputs.aws-region }}
     ENVIRONMENT: ${{ inputs.environment }}
     HELM_VALUES: ${{ inputs.values }}
+    HELM_VALUES_FILE_CONTENTS: ${{ inputs.values_file }}
     HELMFILE: ${{ inputs.helmfile }}
     HELMFILE_PATH: ${{ inputs.helmfile-path }}
     NAMESPACE: ${{ inputs.namespace }}

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: 'Deploy HelmFile'
-description: 'Deploy on Kubernetes with HelmFile'
+name: "Deploy HelmFile"
+description: "Deploy on Kubernetes with HelmFile"
 author: hello@cloudposse.com
 branding:
-  icon: 'file-text'
-  color: 'white'
+  icon: "file-text"
+  color: "white"
 inputs:
   cluster:
     description: Cluster name
@@ -31,7 +31,7 @@ inputs:
   gitref-sha:
     description: Git SHA
     required: false
-    default: ''
+    default: ""
   namespace:
     description: Kubernetes namespace
     required: true
@@ -43,7 +43,7 @@ inputs:
     required: true
   debug:
     description: Debug mode
-    default: 'false'
+    default: "false"
     required: false
   release_label_name:
     description: The name of the label used to describe the helm release
@@ -52,20 +52,20 @@ inputs:
   values:
     description: Extra values to pass to the helm action (comma-separated NAME=VAL pairs)
     required: false
-  values_file:
-    description: Contents of a values file to use in the deployment
+  values_yaml:
+    description: YAML string with extra values to use in a helmfile deploy
     required: false
 outputs:
   webapp-url:
     description: "Web Application url"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   env:
     AWS_REGION: ${{ inputs.aws-region }}
     ENVIRONMENT: ${{ inputs.environment }}
     HELM_VALUES: ${{ inputs.values }}
-    HELM_VALUES_FILE_CONTENTS: ${{ inputs.values_file }}
+    HELM_VALUES_YAML: ${{ inputs.values_yaml }}
     HELMFILE: ${{ inputs.helmfile }}
     HELMFILE_PATH: ${{ inputs.helmfile-path }}
     NAMESPACE: ${{ inputs.namespace }}

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,9 @@ inputs:
     description: The name of the label used to describe the helm release
     default: "release"
     required: false
+  values:
+    description: Extra values to pass to the helm action (comma-separated NAME=VAL pairs)
+    required: false
 outputs:
   webapp-url:
     description: "Web Application url"
@@ -58,6 +61,7 @@ runs:
   env:
     AWS_REGION: ${{ inputs.aws-region }}
     ENVIRONMENT: ${{ inputs.environment }}
+    HELM_VALUES: ${{ inputs.values }}
     HELMFILE: ${{ inputs.helmfile }}
     HELMFILE_PATH: ${{ inputs.helmfile-path }}
     NAMESPACE: ${{ inputs.namespace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,12 +22,6 @@ if [[ "${HELM_DEBUG}" == "true" ]]; then
 	DEBUG_ARGS=" --debug"
 fi
 
-# approach 1: --state-values-set flag. This doesn't seem to propagate from helmfile.yaml to the imported release helmfile
-if [[ -n "$HELM_VALUES" ]]; then
-  HELM_VALUES_FLAG="--state-values-set ${HELM_VALUES}"
-fi
-
-# apprach 2: contents of a file to include in helmfile.yaml
 if [[ -n "$HELM_VALUES_YAML" ]]; then
   echo -e "Using extra values:\n${HELM_VALUES_YAML}"
   export HELM_VALUES_FILE="/tmp/extra_helm_values.yml"
@@ -35,7 +29,7 @@ if [[ -n "$HELM_VALUES_YAML" ]]; then
 fi
 
 if [[ "${OPERATION}" == "deploy" ]]; then
-	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG}  --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
+	OPERATION_COMMAND="helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 if [[ "${OPERATION}" == "deploy" ]]; then
 	echo "Deploying..."
 
-	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG} ${HELM_VALUES_FILE_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
+	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ if [[ "${HELM_DEBUG}" == "true" ]]; then
 fi
 
 if [[ -n "$HELM_VALUES" ]]; then
-  HELM_VALUES_FLAG="--set ${HELM_VALUES}"
+  HELM_VALUES_FLAG="--state-values-set ${HELM_VALUES}"
 fi
 
 if [[ "${OPERATION}" == "deploy" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 
-	RELEASES=$(helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
+	RELEASES=$(helmfile ${HELM_VALUES_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
 	for RELEASE in ${RELEASES}
   do
 	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "${HELM_DEBUG}" == "true" ]]; then
 	DEBUG_ARGS=" --debug"
 fi
 
-if [[ -z "$HELM_VALUES" ]]; then
+if [[ -n "$HELM_VALUES" ]]; then
   HELM_VALUES_FLAG="--set ${HELM_VALUES}"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,10 +27,10 @@ if [[ -n "$HELM_VALUES" ]]; then
   HELM_VALUES_FLAG="--state-values-set ${HELM_VALUES}"
 fi
 
-# apprach 2: contents of a file to include
-if [[ -n "$HELM_VALUES_FILE_CONTENTS" ]]; then
+# apprach 2: contents of a file to include in helmfile.yaml
+if [[ -n "$HELM_VALUES_YAML" ]]; then
   export HELM_VALUES_FILE="/tmp/extra_helm_values.yml"
-  echo "$HELM_VALUES_FILE_CONTENTS" > "$HELM_VALUES_FILE"
+  echo "$HELM_VALUES_YAML" > "$HELM_VALUES_FILE"
 fi
 
 if [[ "${OPERATION}" == "deploy" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 export APPLICATION_HELMFILE=$(pwd)/${HELMFILE_PATH}/${HELMFILE}
 
 source /etc/profile.d/aws.sh
- 
+
 # Used for debugging
 aws sts --region ${AWS_REGION} get-caller-identity
 
@@ -22,9 +22,13 @@ if [[ "${HELM_DEBUG}" == "true" ]]; then
 	DEBUG_ARGS=" --debug"
 fi
 
+if [[ -z "$HELM_VALUES" ]]; then
+  HELM_VALUES_FLAG="--set ${HELM_VALUES}"
+fi
+
 if [[ "${OPERATION}" == "deploy" ]]; then
 
-	OPERATION_COMMAND="helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
+	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 
@@ -57,5 +61,3 @@ elif [[ "${OPERATION}" == "destroy" ]]; then
     fi
 	fi
 fi
-
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ fi
 
 # apprach 2: contents of a file to include in helmfile.yaml
 if [[ -n "$HELM_VALUES_YAML" ]]; then
+  echo -e "Using extra values:\n${HELM_VALUES_YAML}"
   export HELM_VALUES_FILE="/tmp/extra_helm_values.yml"
   echo "$HELM_VALUES_YAML" > "$HELM_VALUES_FILE"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,5 +65,5 @@ elif [[ "${OPERATION}" == "destroy" ]]; then
     if [[ "${RELEASES_COUNTS}" == "0" ]]; then
     	kubectl delete ns ${NAMESPACE}
     fi
-	fi
+  fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,13 +34,10 @@ if [[ -n "$HELM_VALUES_YAML" ]]; then
 fi
 
 if [[ "${OPERATION}" == "deploy" ]]; then
-	echo "Deploying..."
-
-	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
+	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG}  --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 
-  echo "Listing releases..."
 	RELEASES=$(helmfile --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
 	for RELEASE in ${RELEASES}
   do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,11 +27,13 @@ if [[ -n "$HELM_VALUES" ]]; then
 fi
 
 if [[ "${OPERATION}" == "deploy" ]]; then
+	echo "Deploying..."
 
 	OPERATION_COMMAND="helmfile ${HELM_VALUES_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml $DEBUG_ARGS apply"
 	echo "Executing: ${OPERATION_COMMAND}"
 	${OPERATION_COMMAND}
 
+  echo "Listing releases..."
 	RELEASES=$(helmfile ${HELM_VALUES_FLAG} --namespace ${NAMESPACE} --environment ${ENVIRONMENT} --file /deploy/helmfile.yaml list --output json | jq .[].name -r)
 	for RELEASE in ${RELEASES}
   do

--- a/root/deploy/helmfile.yaml
+++ b/root/deploy/helmfile.yaml
@@ -14,3 +14,6 @@ helmfiles:
   - path: {{ requiredEnv "APPLICATION_HELMFILE" }}
     values:
       - /tmp/platform.yaml
+      {{- if env "HELM_VALUES_FILE" }}
+      - {{ env "HELM_VALUES_FILE" }}
+      {{- end }}


### PR DESCRIPTION
## what
* Add support for passing values into the helmfile deploy
* Accepts a yaml blob of values, writes these to a temporary file used in the helmfile
* (abandoned approach) ~use helmfile's `--state-values-set` flag. This requires a `foo=x,bar=y` string from the github action~

## why
* We want to pass values overrides in certain conditions determined by the github actions workflow.
* Use case: setting a temporary password for preview deployments
* In more detail:
  * Our preview deployments have URLs like `{SUBDOMAIN}-{PREVIEW_NAMESPACE}.{DOMAIN}`.
  * This causes our login via AWS Cognito to fail as it has fully-qualified redirect URLs registered, and so will refuse to redirect to a preview namespace. We do not have authn information stored in our app resources.
  * Therefore, we want to create a temporary password on the fly to allow user login in preview.
  * We prefer to do this in the github action rather than helm, since the former creates an easy way to inform the developer what the password is for that specific PR directly in the github action summary output

## references

[Example run](https://github.com/3playmedia-dev/threeplaymedia_app3/actions/runs/3982754027)

<img width="473" alt="Screen Shot 2023-01-22 at 9 37 10 PM" src="https://user-images.githubusercontent.com/4616431/213957179-cf967b88-d2ec-4190-b0ae-35ddd908f9ba.png">

