### PR TITLE
feat: Support Subenvironments Parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Helmfile environment
     required: false
     default: preview
+  subenvironment:
+    description: Helmfile subenvironment
+    required: false
+    default: ''
   gitref-sha:
     description: Git SHA
     required: false
@@ -58,6 +62,7 @@ runs:
   env:
     AWS_REGION: ${{ inputs.aws-region }}
     ENVIRONMENT: ${{ inputs.environment }}
+    SUBENVIRONMENT: ${{ inputs.subenvironment }}
     HELMFILE: ${{ inputs.helmfile }}
     HELMFILE_PATH: ${{ inputs.helmfile-path }}
     NAMESPACE: ${{ inputs.namespace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 export APPLICATION_HELMFILE=$(pwd)/${HELMFILE_PATH}/${HELMFILE}
 
 source /etc/profile.d/aws.sh
- 
+
 # Used for debugging
 aws sts --region ${AWS_REGION} get-caller-identity
 
@@ -13,7 +13,11 @@ aws sts --region ${AWS_REGION} get-caller-identity
 aws eks --region ${AWS_REGION} update-kubeconfig --name ${CLUSTER_NAME}
 
 # Read platform specific configs/info
-chamber export platform/${CLUSTER_NAME}/${ENVIRONMENT} --format yaml | yq --exit-status --no-colors  eval '{"platform": .}' - > /tmp/platform.yaml
+if [[ -z "${SUBENVIORNMENT}" ]]; then
+	chamber export platform/${CLUSTER_NAME}/${ENVIRONMENT}/${SUBENVIRONMENT} --format yaml | yq --exit-status --no-colors  eval '{"platform": .}' - > /tmp/platform.yaml
+else
+	chamber export platform/${CLUSTER_NAME}/${ENVIRONMENT} --format yaml | yq --exit-status --no-colors  eval '{"platform": .}' - > /tmp/platform.yaml
+fi
 
 DEBUG_ARGS=""
 
@@ -57,5 +61,3 @@ elif [[ "${OPERATION}" == "destroy" ]]; then
     fi
 	fi
 fi
-
-


### PR DESCRIPTION
## what
- Added subenvironment option to be optionally passed to chamber when pulling parameters

## why
- This allows us to set specific values for subenvironments beyond the defaults for the given environment
- For example, `qa/apple` and `qa/orange` can have different values

## references
- n/a
