### PR TITLE
Handle multiple matching ingresses for output-url

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	RELEASES=$(helmfile ${BASIC_ARGS} ${EXTRA_VALUES_ARGS} ${DEBUG_ARGS} list --output json | jq .[].name -r)
 	for RELEASE in ${RELEASES}
   do
-	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}')
+	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress -o json | jq --raw-output '[.items[].metadata.annotations["outputs.webapp-url"]] | first')
 		if [[ "${ENTRYPOINT}" != "" ]]; then
 			echo "webapp-url=${ENTRYPOINT}" >> $GITHUB_OUTPUT
   	fi


### PR DESCRIPTION
Github actions cannot support having multiple output urls for an environment. Switch the strategy to use `jq`'s `first` function so that at least some valid URL is displayed if present. Punts on how to determine which URL would be preferred in the case of multiple.

## what
* Output only a single URL for `webapp-url` when a deployment has multiple ingresses
* Choose the first matching ingress as a reasonable guess as to which ingress is preferred to display in the github action step.

## why
* When there are multiple ingresses, the current script outputs all of their URLS:

```
⨠ kubectl --namespace pr-13904 get -l app.kubernetes.io/name=app ingress --output=jsonpath='{.items[*].metadata.annotations.outputs\.webapp-url}'
https://ops-pr-13904.3paw-dev.com https://ops-pr-13904.3paw-dev.co
```

This causes the github action to fail to display the environment url

<img width="1278" alt="Screen Shot 2023-04-27 at 3 20 10 PM" src="https://user-images.githubusercontent.com/4616431/234969352-540edb1b-2365-453f-a4fe-0af6a5d246ad.png">

* First is a a step in the direction over invalid, though this could get more configurable. (In our case, both ingresses have the same url anyway.)
* Change to `jq` from `jsonpath` since it supports `first` even if there are no matches. `jsonpath` using `[0]`, on the other hand, will blow up

## references
* https://github.com/3playmedia-dev/threeplaymedia_app3/actions/runs/4823321955
