### PR TITLE
fixing Version '1:2.20.1-2+deb10u8' for 'git' was not found issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
      	bash=5.0-4 \
     	yq=4.32.1-1 \
     	jq \
-    	git=1:2.20.1-2+deb10u8
+    	git
 
 COPY entrypoint.sh /usr/local/bin/entrypoint
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]


### PR DESCRIPTION
## what

- allow to install any available version of `git` binary

## why

- Version '1:2.20.1-2+deb10u8' for 'git' is not available anymore

## Reference
* #49 