### PR TITLE
feat: Optional `url-resource-type`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
   chamber_version:
     description: Kubectl version
     default: 2.11.1
+  url-resource-type:
+    description: The type of the resource to get the URL from
+    required: false
+    default: 'ingress'
 outputs:
   webapp-url:
     description: "Web Application url"
@@ -88,4 +92,4 @@ runs:
     HELM_VERSION: ${{ inputs.helm_version }}
     HELMFILE_VERSION: ${{ inputs.helmfile_version }}
     CHAMBER_VERSION: ${{ inputs.chamber_version }}
-
+    URL_RESOURCE_TYPE: ${{ inputs.url-resource-type }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,12 +49,16 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	${OPERATION_COMMAND}
 
 	RELEASES=$(helmfile ${BASIC_ARGS} ${EXTRA_VALUES_ARGS} ${DEBUG_ARGS} list --output json | jq .[].name -r)
-	for RELEASE in ${RELEASES}
+  for RELEASE in ${RELEASES}
   do
-	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ${URL_RESOURCE_TYPE} -o json | jq --raw-output '[.items[].metadata.annotations["outputs.webapp-url"]] | first')
-		if [[ "${ENTRYPOINT}" != "" ]]; then
-			echo "webapp-url=${ENTRYPOINT}" >> $GITHUB_OUTPUT
-  	fi
+    echo "Processing release: ${RELEASE}"
+    ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ${URL_RESOURCE_TYPE} -o json | jq --raw-output '[.items[].metadata.annotations["outputs.webapp-url"]] | first')
+    if [[ "${ENTRYPOINT}" != "" ]]; then
+      echo "Found webapp-url for release ${RELEASE}: ${ENTRYPOINT}"
+      echo "webapp-url=${ENTRYPOINT}" >> $GITHUB_OUTPUT
+    else
+      echo "No webapp-url found for release ${RELEASE}"
+    fi
   done
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,7 @@ if [[ "${OPERATION}" == "deploy" ]]; then
   for RELEASE in ${RELEASES}
   do
     echo "Processing release: ${RELEASE}"
+    echo "Executing kubectl command: kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ${URL_RESOURCE_TYPE} -o json"
     ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ${URL_RESOURCE_TYPE} -o json | jq --raw-output '[.items[].metadata.annotations["outputs.webapp-url"]] | first')
     if [[ "${ENTRYPOINT}" != "" ]]; then
       echo "Found webapp-url for release ${RELEASE}: ${ENTRYPOINT}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 	RELEASES=$(helmfile ${BASIC_ARGS} ${EXTRA_VALUES_ARGS} ${DEBUG_ARGS} list --output json | jq .[].name -r)
 	for RELEASE in ${RELEASES}
   do
-	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ingress -o json | jq --raw-output '[.items[].metadata.annotations["outputs.webapp-url"]] | first')
+	ENTRYPOINT=$(kubectl --namespace ${NAMESPACE} get -l ${RELEASE_LABEL_NAME}=${RELEASE} ${URL_RESOURCE_TYPE} -o json | jq --raw-output '[.items[].metadata.annotations["outputs.webapp-url"]] | first')
 		if [[ "${ENTRYPOINT}" != "" ]]; then
 			echo "webapp-url=${ENTRYPOINT}" >> $GITHUB_OUTPUT
   	fi


### PR DESCRIPTION
## what
- Add the `url-resource-type` input

## why
- Allow the action to select a different resource type other than `ingress` to filter for the `webapp-url`

## references
- n/a